### PR TITLE
Fix for loop in Oura sleep fetch

### DIFF
--- a/oura_garmin_analyzer.py
+++ b/oura_garmin_analyzer.py
@@ -62,6 +62,7 @@ def fetch_oura_sleep(start_date: dt.date, end_date: dt.date) -> List[SleepRecord
     data = data.get("data", [])
     records = []
 
+    for d in data:
         date_str = d.get("day") or d.get("summary_date")
         if not date_str:
             continue


### PR DESCRIPTION
## Summary
- loop over returned sleep data before extracting values

## Testing
- `python3 -m py_compile oura_garmin_analyzer.py` *(fails: SyntaxError: unterminated triple-quoted string literal)*

------
https://chatgpt.com/codex/tasks/task_e_685cf915b4e0832e98a688b0b8eab007